### PR TITLE
[1.x] fix PHP 8.1 deprecation notice

### DIFF
--- a/src/Dashboard/DashboardLogger.php
+++ b/src/Dashboard/DashboardLogger.php
@@ -85,7 +85,7 @@ class DashboardLogger
             'channel' => $channelName,
             'data' => [
                 'type' => $type,
-                'time' => strftime('%H:%M:%S'),
+                'time' => date('H:i:s'),
             ] + $attributes,
         ]);
     }


### PR DESCRIPTION
fix `PHP Deprecated:  Function strftime() is deprecated in ....../src/Dashboard/DashboardLogger.php on line 88`